### PR TITLE
feat(QueryLambda): use airports.json file from S3 to filter out possi…

### DIFF
--- a/src/main/java/com/aerotrack/infrastructure/constructs/ApiConstruct.java
+++ b/src/main/java/com/aerotrack/infrastructure/constructs/ApiConstruct.java
@@ -10,16 +10,11 @@ import software.amazon.awscdk.services.apigateway.LambdaIntegration;
 import software.amazon.awscdk.services.apigateway.MethodOptions;
 import software.amazon.awscdk.services.apigateway.Resource;
 import software.amazon.awscdk.services.apigateway.RestApi;
-import software.amazon.awscdk.services.apigateway.Stage;
 import software.amazon.awscdk.services.apigateway.ThrottleSettings;
-import software.amazon.awscdk.services.apigateway.ThrottlingPerMethod;
 import software.amazon.awscdk.services.apigateway.UsagePlan;
 import software.amazon.awscdk.services.apigateway.UsagePlanPerApiStage;
 import software.amazon.awscdk.services.dynamodb.Table;
-import software.amazon.awscdk.services.iam.Effect;
 import software.amazon.awscdk.services.iam.ManagedPolicy;
-import software.amazon.awscdk.services.iam.PolicyDocument;
-import software.amazon.awscdk.services.iam.PolicyStatement;
 import software.amazon.awscdk.services.iam.Role;
 import software.amazon.awscdk.services.iam.ServicePrincipal;
 import software.amazon.awscdk.services.lambda.Code;
@@ -86,10 +81,10 @@ public class ApiConstruct extends Construct {
                 .environment(new HashMap<>() {
                     {
                         put(Constant.FLIGHT_TABLE_ENV_VAR, flightsTable.getTableName());
-                        put(Constant.DIRECTION_BUCKET_ENV_VAR, directionBucket.getBucketName());
+                        put(Constant.AIRPORTS_BUCKET_ENV_VAR, directionBucket.getBucketName());
                     }
                 })
-                .handler("com.aerotrack.lambda.query.QueryRequestHandler::handleRequest")
+                .handler("com.aerotrack.lambda.QueryRequestHandler::handleRequest")
                 .role(lambdaRole)
                 .memorySize(Constant.QUERY_LAMBDA_MEMORY_SIZE)
                 .timeout(Duration.seconds(Constant.QUERY_LAMBDA_TIMEOUT_SECONDS))

--- a/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/pom.xml
+++ b/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/pom.xml
@@ -10,9 +10,14 @@
 
     <repositories>
         <repository>
-            <id>github</id>
-            <name>GitHub Apache Maven Packages</name>
+            <id>github-model</id>
+            <name>Aerotrack Model</name>
             <url>https://maven.pkg.github.com/trjohnny/AerotrackModel</url>
+        </repository>
+        <repository>
+            <id>github-utils</id>
+            <name>Aerotrack Utils</name>
+            <url>https://maven.pkg.github.com/trjohnny/AerotrackUtils</url>
         </repository>
     </repositories>
 
@@ -88,6 +93,12 @@
             <artifactId>dynamodb</artifactId>
             <version>2.21.37</version>
         </dependency>
+        <!-- Json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20231013</version>
+        </dependency>
         <!-- AWS SDK Enhanced DynamoDB -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
@@ -110,6 +121,12 @@
             <groupId>com.aerotrack</groupId>
             <artifactId>aerotrack-model</artifactId>
             <version>1.0.3</version>
+        </dependency>
+        <!-- Aerotrack Utils -->
+        <dependency>
+            <groupId>com.aerotrack</groupId>
+            <artifactId>aerotrack-utils</artifactId>
+            <version>1.0.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/src/main/java/com/aerotrack/lambda/QueryRequestHandler.java
+++ b/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/src/main/java/com/aerotrack/lambda/QueryRequestHandler.java
@@ -1,7 +1,7 @@
-package com.aerotrack.lambda.query;
+package com.aerotrack.lambda;
 
+import com.aerotrack.lambda.workflow.QueryLambdaWorkflow;
 import com.aerotrack.model.ScanQueryRequest;
-import com.aerotrack.lambda.query.workflow.QueryLambdaWorkflow;
 import com.aerotrack.model.ScanQueryResponse;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
@@ -11,14 +11,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.Map;
 
 @Slf4j
 public class QueryRequestHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
     private final DynamoDbEnhancedClient dynamoDbEnhancedClient = DynamoDbEnhancedClient.create();
+    private final S3Client s3Client = S3Client.create();
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final QueryLambdaWorkflow queryLambdaWorkflow = new QueryLambdaWorkflow(dynamoDbEnhancedClient);
+    private final QueryLambdaWorkflow queryLambdaWorkflow = new QueryLambdaWorkflow(dynamoDbEnhancedClient, s3Client);
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent request, Context context) {

--- a/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/src/main/java/com/aerotrack/lambda/workflow/QueryLambdaWorkflow.java
+++ b/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/src/main/java/com/aerotrack/lambda/workflow/QueryLambdaWorkflow.java
@@ -1,47 +1,81 @@
-package com.aerotrack.lambda.query.workflow;
+package com.aerotrack.lambda.workflow;
 
 import com.aerotrack.model.Flight;
 import com.aerotrack.model.FlightPair;
 import com.aerotrack.model.ScanQueryRequest;
 import com.aerotrack.model.ScanQueryResponse;
+import com.aerotrack.utils.S3Utils;
 import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.services.s3.S3Client;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 
 @Slf4j
 public class QueryLambdaWorkflow {
+    private static final String AIRPORTS_OBJECT_NAME = "airports.json";
     private final DynamoDbTable<Flight> flightTable;
     static final TableSchema<Flight> FLIGHT_TABLE_SCHEMA = TableSchema.fromClass(Flight.class);
     static final String FLIGHT_TABLE_ENV_VAR = "FLIGHT_TABLE";
+    static final String AIRPORTS_BUCKET_ENV_VAR = "AIRPORTS_BUCKET";
+    private final S3Client s3Client;
 
 
-    public QueryLambdaWorkflow(DynamoDbEnhancedClient dynamoDbEnhancedClient) {
+    public QueryLambdaWorkflow(DynamoDbEnhancedClient dynamoDbEnhancedClient, S3Client s3Client) {
         this.flightTable = dynamoDbEnhancedClient.table(
                 System.getenv(FLIGHT_TABLE_ENV_VAR),
                 FLIGHT_TABLE_SCHEMA);
+        this.s3Client = s3Client;
     }
 
     public ScanQueryResponse queryAndProcessFlights(ScanQueryRequest request) {
+        JSONObject airportsJson;
+
+        try {
+            airportsJson = S3Utils.getJsonObjectFromS3(s3Client, System.getenv(AIRPORTS_BUCKET_ENV_VAR), AIRPORTS_OBJECT_NAME);
+        } catch (IOException ioException) {
+            // No need to handle or propagate the IOException, we are not able to handle it.
+            // The QueryRequestHandler will log the error
+            throw new RuntimeException(ioException);
+        }
+
+        JSONArray airportsArray = airportsJson.getJSONArray("airports");
+
+        // This map is used to check the existence of every airport in the request and their possible connections.
+        // In this way we limit the number of calls to DynamoDB
+        Map<String, Set<String>> airportsConnections = getAirportConnectionsMap(airportsArray);
+
         List<FlightPair> flightPairs = new ArrayList<>();
         Map<String, List<Flight>> allReturnFlights = new HashMap<>();
 
         // Pre-fetch return flights if not returning to the same airport
         if (!request.getReturnToSameAirport()) {
             for (String destination : request.getDestinationAirports()) {
+                if (! airportsConnections.containsKey(destination))
+                    continue;
+
                 List<Flight> returnFlightsForDestination = new ArrayList<>();
                 for (String returnDeparture : request.getDepartureAirports()) {
+                    if (! airportsConnections.get(destination).contains(returnDeparture))
+                        continue;
+
                     returnFlightsForDestination.addAll(scanFlights(destination, returnDeparture,
                             request.getAvailabilityStart(), request.getAvailabilityEnd()));
                 }
@@ -51,7 +85,13 @@ public class QueryLambdaWorkflow {
 
         // Process outbound and return flights
         for (String departure : request.getDepartureAirports()) {
+            if (! airportsConnections.containsKey(departure))
+                continue;
+
             for (String destination : request.getDestinationAirports()) {
+                if (! airportsConnections.get(departure).contains(destination))
+                    continue;
+
                 List<Flight> outboundFlights = scanFlights(departure, destination,
                         request.getAvailabilityStart(), request.getAvailabilityEnd());
 
@@ -87,6 +127,22 @@ public class QueryLambdaWorkflow {
                 .build();
     }
 
+    private Map<String, Set<String>> getAirportConnectionsMap(JSONArray airportsArray) {
+        Map<String, Set<String>> airportsConnections = new HashMap<>();
+
+        for (int i = 0; i < airportsArray.length(); i++) {
+            JSONObject airport = airportsArray.getJSONObject(i);
+            String airportCode = airport.getString("airportCode");
+            JSONArray connectionsArray = airport.getJSONArray("connections");
+            Set<String> connections = new HashSet<>();
+            for (int j = 0; j < connectionsArray.length(); j++) {
+                connections.add(connectionsArray.getString(j));
+            }
+            airportsConnections.put(airportCode, connections);
+        }
+
+        return airportsConnections;
+    }
 
 
     private List<Flight> scanFlights(String departure, String destination, String availabilityStart, String availabilityEnd) {

--- a/src/main/java/com/aerotrack/infrastructure/s3data/airports.json
+++ b/src/main/java/com/aerotrack/infrastructure/s3data/airports.json
@@ -2,12 +2,29 @@
   "airports":
     [
       {
-        "from": "VCE",
-        "to": "DUB"
+        "airportCode" : "VCE",
+        "name" : "Venice Marco Polo",
+        "countryCode" : "IT",
+        "connections" : ["AHO","BRI","BER","CGN","DUB","HEL"]
       },
       {
-        "from": "DUB",
-        "to": "VCE"
+        "airportCode" : "VIE",
+        "name" : "Vienna",
+        "countryCode" : "AT",
+        "connections" : ["VCE","TSF","BRI"]
+      },
+      {
+        "airportCode" : "TSF",
+        "name" : "Venice (Treviso)",
+        "countryCode" : "IE",
+        "connections" : ["AHO","BRI","BER","CGN","DUB","HEL"]
+      },
+      {
+        "airportCode" : "DUB",
+        "name" : "Dublin",
+        "countryCode" : "IE",
+        "connections" : ["VCE","TSF","ATH","BCN","BOH","LON"]
       }
+
     ]
 }

--- a/src/main/java/com/aerotrack/infrastructure/s3data/airports.json
+++ b/src/main/java/com/aerotrack/infrastructure/s3data/airports.json
@@ -17,7 +17,7 @@
         "airportCode" : "TSF",
         "name" : "Venice (Treviso)",
         "countryCode" : "IE",
-        "connections" : ["AHO","BRI","BER","CGN","DUB","HEL"]
+        "connections" : ["AHO","VIE","BER","CGN","DUB","HEL"]
       },
       {
         "airportCode" : "DUB",

--- a/src/main/java/com/aerotrack/utils/Constant.java
+++ b/src/main/java/com/aerotrack/utils/Constant.java
@@ -21,7 +21,7 @@ public class Constant {
     public static final String GITHUB_USERNAME = "trjohnny";
 
     public static final String FLIGHT_TABLE_ENV_VAR = "FLIGHT_TABLE";
-    public static final String DIRECTION_BUCKET_ENV_VAR = "DIRECTION_BUCKET";
+    public static final String AIRPORTS_BUCKET_ENV_VAR = "AIRPORTS_BUCKET";
     public static final Integer QUERY_LAMBDA_MEMORY_SIZE = 128;
     public static final Integer QUERY_LAMBDA_TIMEOUT_SECONDS = 20;
     public static final Integer REFRESH_EVENT_RATE_SECONDS = 60; // Multiple of 60


### PR DESCRIPTION
## Description

Questa la faccio in italiano perché si. Ho aggiunto la dipendenza da AerotrackUtils per ottenere oggetti json da S3. Airports.json (modificato di conseguenza) viene quindi usato per filtrare l'esistenza di ogni aeroporto richiesto, e delle sue possibili destinazioni, riducendo il numero complessivo di chiamate a DynamoDB.


## Testing

Aggiunto unit test

```mvn package```

Deploy su personal stack e test dell'API

<img width="597" alt="image" src="https://github.com/trjohnny/AerotrackInfrastructure/assets/35215594/8c533a20-acb1-4bca-952b-7f5f3dcc66e6">

