### PR TITLE
feat: more frequent "burst" refresh logic

### DIFF
--- a/src/main/java/com/aerotrack/PipelineStack.java
+++ b/src/main/java/com/aerotrack/PipelineStack.java
@@ -49,13 +49,13 @@ public class PipelineStack extends Stack {
                         .build())
                 .build()));
 
-        alphaStage.addPost(new ManualApprovalStep("approval"));
-
-        pipeline.addStage(new AppStage(this, "Prod", StageProps.builder()
+        StageDeployment prodStage = pipeline.addStage(new AppStage(this, "Prod", StageProps.builder()
                 .env(Environment.builder()
                         .account("715311622639")
                         .region("eu-west-1")
                         .build())
                 .build()));
+
+        alphaStage.addPre(new ManualApprovalStep("approval"));
     }
 }

--- a/src/main/java/com/aerotrack/infrastructure/constructs/RefreshConstruct.java
+++ b/src/main/java/com/aerotrack/infrastructure/constructs/RefreshConstruct.java
@@ -7,6 +7,7 @@ import software.amazon.awscdk.services.dynamodb.Table;
 import software.amazon.awscdk.services.events.Rule;
 import software.amazon.awscdk.services.events.Schedule;
 import software.amazon.awscdk.services.events.targets.LambdaFunction;
+import software.amazon.awscdk.services.iam.ManagedPolicy;
 import software.amazon.awscdk.services.iam.Role;
 import software.amazon.awscdk.services.iam.ServicePrincipal;
 import software.amazon.awscdk.services.lambda.Code;
@@ -33,6 +34,9 @@ public class RefreshConstruct extends Construct {
 
         Role lambdaRole = Role.Builder.create(this, Utils.getResourceName(Constant.REFRESH_LAMBDA_ROLE))
                 .assumedBy(new ServicePrincipal("lambda.amazonaws.com"))
+                .managedPolicies(List.of(
+                        ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSLambdaBasicExecutionRole")
+                ))
                 .build();
 
         directionBucket.grantRead(lambdaRole);
@@ -60,13 +64,13 @@ public class RefreshConstruct extends Construct {
 
         if(!isPersonalDeployment())
         {
-            List<LambdaFunction> lambdas = new ArrayList<>();
-            for(int i = 0; i < Constant.REFRESH_LAMBDAS_PER_EVENT; i++)
-                lambdas.add(new LambdaFunction(refreshLambdaFunction));
-            Rule.Builder.create(this, Utils.getResourceName(Constant.REFRESH_EVENT_RULE))
-                    .schedule(Schedule.rate(Duration.seconds(Constant.REFRESH_EVENT_RATE_SECONDS)))
-                    .targets(lambdas)
+            Rule rule = Rule.Builder.create(this, Utils.getResourceName(Constant.REFRESH_EVENT_RULE))
+                    .schedule(Schedule.rate(Duration.minutes(Constant.REFRESH_EVENT_RATE_MINUTES)))
                     .build();
+
+            for (int i = 0; i < Constant.REFRESH_LAMBDAS_PER_EVENT; i++) {
+                rule.addTarget(new LambdaFunction(refreshLambdaFunction));
+            }
         }
     }
 }

--- a/src/main/java/com/aerotrack/infrastructure/lambda/RefreshLambda/pom.xml
+++ b/src/main/java/com/aerotrack/infrastructure/lambda/RefreshLambda/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>com.aerotrack</groupId>
             <artifactId>aerotrack-utils</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.4</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/aerotrack/infrastructure/lambda/RefreshLambda/src/main/java/com/aerotrack/lambda/RefreshRequestHandler.java
+++ b/src/main/java/com/aerotrack/infrastructure/lambda/RefreshLambda/src/main/java/com/aerotrack/lambda/RefreshRequestHandler.java
@@ -1,6 +1,8 @@
 package com.aerotrack.lambda;
 
 import com.aerotrack.lambda.workflow.RefreshWorkflow;
+import com.aerotrack.utils.clients.dynamodb.AerotrackDynamoDbClient;
+import com.aerotrack.utils.clients.ryanair.RyanairClient;
 import com.aerotrack.utils.clients.s3.AerotrackS3Client;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
@@ -13,15 +15,17 @@ import java.io.IOException;
 
 @Slf4j
 public class RefreshRequestHandler implements RequestHandler<ScheduledEvent, Void> {
+    private final AerotrackS3Client s3Client = AerotrackS3Client.create();
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient = DynamoDbEnhancedClient.create();
+    private final RyanairClient ryanairClient = RyanairClient.create();
 
 
     public Void handleRequest(ScheduledEvent event, Context context) {
-
+        RefreshWorkflow refreshWorkflow = new RefreshWorkflow(s3Client, dynamoDbEnhancedClient, ryanairClient);
 
         try {
-            new RefreshWorkflow(AerotrackS3Client.create(), DynamoDbEnhancedClient.create()).refreshFlights();
-        }
-        catch (IOException | NullPointerException | InterruptedException exc) {
+            refreshWorkflow.refreshFlights();
+        } catch (IOException | NullPointerException | InterruptedException exc) {
             log.error("An exception occurred: " + exc);
         }
 

--- a/src/main/java/com/aerotrack/utils/Constant.java
+++ b/src/main/java/com/aerotrack/utils/Constant.java
@@ -25,9 +25,7 @@ public class Constant {
     public static final Integer QUERY_LAMBDA_MEMORY_SIZE = 128;
     public static final Integer QUERY_LAMBDA_TIMEOUT_SECONDS = 20;
     public static final Integer REFRESH_LAMBDAS_PER_EVENT = 5;
-
-    // Without 5 it does on average one request per second. With 5 it's around one request every 5 seconds.
-    public static final Integer REFRESH_EVENT_RATE_SECONDS = (60 * REFRESH_LAMBDAS_PER_EVENT);
+    public static final Integer REFRESH_EVENT_RATE_MINUTES = 15;
 
 
 }


### PR DESCRIPTION
## Description

Modificato la refresh logic in modo da effettuare 5 burst in parallelo verso Ryanair, e al momento del ban fermare l'esecuzione. I target sono 5, triggerati ogni 15 minuti, circa 200-300 richieste con successo PER LAMBDA per esecuzione. Modificato costruttore in modo da uniformare le 2 lambda

## Testing

Aggiunto Unit test

`mvn package`

test in personal stack