### PR TITLE
feat: start using new Model for requests and refactor workflow

### DIFF
--- a/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/pom.xml
+++ b/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.aerotrack</groupId>
             <artifactId>aerotrack-model</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.1</version>
         </dependency>
         <!-- Aerotrack Utils -->
         <dependency>

--- a/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/src/main/java/com/aerotrack/lambda/QueryRequestHandler.java
+++ b/src/main/java/com/aerotrack/infrastructure/lambda/QueryLambda/src/main/java/com/aerotrack/lambda/QueryRequestHandler.java
@@ -14,7 +14,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 public class QueryRequestHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -32,7 +34,25 @@ public class QueryRequestHandler implements RequestHandler<APIGatewayProxyReques
             scanQueryRequest.validate(); // Validate the request
             log.info("QueryRequestHandler started with request [{}]", scanQueryRequest);
 
-            ScanQueryResponse scanQueryResponse = queryLambdaWorkflow.queryAndProcessFlights(scanQueryRequest);
+            Integer minDays = scanQueryRequest.getMinDays();
+            Integer maxDaye = scanQueryRequest.getMaxDays();
+
+            String availabilityStart = scanQueryRequest.getAvailabilityStart();
+            String availabilityEnd = scanQueryRequest.getAvailabilityEnd();
+
+            List<String> departureAirports = scanQueryRequest.getDepartureAirports();
+            List<String> destinationAirports = scanQueryRequest.getDestinationAirports();
+
+            Integer maxChanges = Optional.ofNullable(scanQueryRequest.getMaxChanges()).orElse(0);
+
+            Optional<Integer> minTimeBetweenChangesHours = Optional.ofNullable(scanQueryRequest.getMinTimeBetweenChangesHours());
+            Optional<Integer> maxTimeBetweenChangesHours = Optional.ofNullable(scanQueryRequest.getMaxTimeBetweenChangesHours());
+
+            Boolean returnToSameAirport = Optional.ofNullable(scanQueryRequest.getReturnToSameAirport()).orElse(true);
+
+            ScanQueryResponse scanQueryResponse = queryLambdaWorkflow.queryAndProcessFlights(minDays, maxDaye, availabilityStart,
+                    availabilityEnd, departureAirports, destinationAirports, maxChanges, minTimeBetweenChangesHours,
+                    maxTimeBetweenChangesHours, returnToSameAirport);
 
             response.setStatusCode(200);
             response.setHeaders(Map.of(


### PR DESCRIPTION
## Description

Questa PR implementa il nuovo model 1.2.1 . Ciò comporta l'annessione di campi della classe Request per gestire i cambi. Il numero di cambi di default è 0. Non ha senso assegnare dei default ai tempi di attesa dei cambi  nell'handler perchè non è nemmeno detto che verranno usati. Per gli altri campi invece è stato scelto di passare da una classe Request ai singoli parametri da passare al metodo queryAndProcessFlights in quanto la request è responsabilità e dominio dell'handler, mentre il workflow si occupa del dominio dei voli.


## Testing

`mvn package`

test in locale della lambda

`cdk deploy Giovanni-InfraStack`

curl all'API con risultati giusti